### PR TITLE
ci: update dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,15 +3,30 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    labels:
+      - "area/dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/"
+    labels:
+      - "area/dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "area/dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Updated dependabot config to only create PRs once a week.

[Related issue](https://github.com/orgs/bank-vaults/projects/2/views/1?pane=issue&itemId=49270690)