### PR TITLE
chore: update flake.nix

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -179,7 +179,7 @@ jobs:
         with:
           cond: ${{ inputs.release }}
           if_true: goreleaser release
-          if_false: goreleaser release --skip-publish --snapshot
+          if_false: goreleaser release --skip=publish --snapshot
 
       - name: Build
         run: nix develop --impure .#ci -c ${{ steps.build-command.outputs.value }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: secret-sync
 
 dist: build/dist

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717245169,
-        "narHash": "sha256-+mW3rTBjGU8p1THJN0lX/Dd/8FbnF+3dB+mJuSaxewE=",
+        "lastModified": 1718001032,
+        "narHash": "sha256-kaL1/ruHEEm5+4OCaFfspCyaguUVrbmkad7A3fXaGF0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c3f9f053c077c6f88a3de5276d9178c62baa3fc3",
+        "rev": "50e981f8a08cc06553ac591c658f347f6087d836",
         "type": "github"
       },
       "original": {
@@ -362,16 +362,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1717380751,
-        "narHash": "sha256-Yp3vjgKUFXsi/DnksBwoqpy7KaCJZ4hEXLL3XtxnWYw=",
+        "lastModified": 1717868076,
+        "narHash": "sha256-c83Y9t815Wa34khrux81j8K8ET94ESmCuwORSKm2bQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e81ce0373efa813d02b3ec4877a99aaedfa3926",
+        "rev": "cd18e2ae9ab8e2a0a8d715b60c91b54c0ac35ff9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Synchronise secrets between services in a configurable manner";
 
   inputs = {
-    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     devenv.url = "github:cachix/devenv";
   };
@@ -40,14 +39,18 @@
             packages = with pkgs; [
               gnumake
 
-              # golangci-lint
               goreleaser
+
+              # golangci-lint
+              # TODO: remove once https://github.com/NixOS/nixpkgs/pull/254878 hits unstable
+              (golangci-lint.override (prev: {
+                buildGoModule = pkgs.buildGo121Module;
+              }))
 
               yamllint
               hadolint
             ] ++ [
               self'.packages.licensei
-              self'.packages.golangci-lint
             ];
 
             env = {
@@ -111,47 +114,6 @@
               "-X github.com/hashicorp/vault/sdk/version.Version=${version}"
               "-X github.com/hashicorp/vault/sdk/version.VersionPrerelease="
             ];
-          };
-
-          golangci-lint = pkgs.buildGo121Module rec {
-            pname = "golangci-lint";
-            version = "1.54.2";
-
-            src = pkgs.fetchFromGitHub {
-              owner = "golangci";
-              repo = "golangci-lint";
-              rev = "v${version}";
-              hash = "sha256-7nbgiUrp7S7sXt7uFXX8NHYbIRLZZQcg+18IdwAZBfE=";
-            };
-
-            vendorHash = "sha256-IyH5lG2a4zjsg/MUonCUiAgMl4xx8zSflRyzNgk8MR0=";
-
-            subPackages = [ "cmd/golangci-lint" ];
-
-            nativeBuildInputs = [ pkgs.installShellFiles ];
-
-            ldflags = [
-              "-s"
-              "-w"
-              "-X main.version=${version}"
-              "-X main.commit=v${version}"
-              "-X main.date=19700101-00:00:00"
-            ];
-
-            postInstall = ''
-              for shell in bash zsh fish; do
-                HOME=$TMPDIR $out/bin/golangci-lint completion $shell > golangci-lint.$shell
-                installShellCompletion golangci-lint.$shell
-              done
-            '';
-
-            meta = with pkgs.lib; {
-              description = "Fast linters Runner for Go";
-              homepage = "https://golangci-lint.run/";
-              changelog = "https://github.com/golangci/golangci-lint/blob/v${version}/CHANGELOG.md";
-              license = licenses.gpl3Plus;
-              maintainers = with maintainers; [ anpryl manveru mic92 ];
-            };
           };
         };
       };


### PR DESCRIPTION
## Overview

- Updated `flake.nix` to use the same pkgs as other repos.
- The CI threw some errors, so i fixed those too, by updating the goreleaser.
